### PR TITLE
fix: remove the `SPRING_` prefix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,10 +43,10 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << "EOF"
             cd ~/deploy/${{ github.event.repository.name }}
-            echo "SPRING_MAIL_HOST=${{ secrets.MAIL_HOST }}" > .env
-            echo "SPRING_MAIL_PORT=${{ secrets.MAIL_PORT }}" >> .env
-            echo "SPRING_MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}" >> .env
-            echo "SPRING_MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}" >> .env
+            echo "MAIL_HOST=${{ secrets.MAIL_HOST }}" > .env
+            echo "MAIL_PORT=${{ secrets.MAIL_PORT }}" >> .env
+            echo "MAIL_USERNAME=${{ secrets.MAIL_USERNAME }}" >> .env
+            echo "MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}" >> .env
             docker compose down --remove-orphans
             docker compose build
             docker compose up -d --remove-orphans


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change updates environment variable names in the deployment script to remove the `SPRING_` prefix, aligning them with standard naming conventions.